### PR TITLE
Removed Try in autoview fn for statusTypeMsg

### DIFF
--- a/main.py
+++ b/main.py
@@ -189,7 +189,7 @@ def reminderFn(ttime_diff: float, sstart: float) -> float:
 def getNotified() -> None:
     start = float("{:.2f}".format(perf_counter()))
     while True:
-        with contextlib(NoSuchElementException):
+        with contextlib.suppress(NoSuchElementException):
             checkStatus()
             time_diff = float("{:.2f}".format(perf_counter())) - start
             


### PR DESCRIPTION
Error handling for debugging was removed. "statusTypeMsg" could not be accessed.
Fix: it was passed into the function.